### PR TITLE
Ensure THP does not get auto-enabled on RHEL7 (Issue #2)

### DIFF
--- a/lib/checks.sh
+++ b/lib/checks.sh
@@ -42,6 +42,22 @@ function check_os() {
     state "$msg. Actual: $swappiness" 1
   fi
 
+  # "tuned" service should be disabled on RHEL/CentOS 7.x
+  # https://www.cloudera.com/documentation/enterprise/latest/topics/cdh_admin_performance.html#xd_583c10bfdbd326ba-7dae4aa6-147c30d0933--7fd5__disable-tuned
+  if is_centos_rhel_7; then
+    systemctl status tuned &>/dev/null
+    case $? in
+      0) state "System: tuned is running" 1;;
+      3) state "System: tuned is not running" 0;;
+      *) state "System: tuned is not installed" 0;;
+    esac
+    if [ "`systemctl is-enabled tuned`" == "enabled" ]; then
+      state "System: tuned auto-starts on boot" 1
+    else
+      state "System: tuned does not auto-start on boot" 0
+    fi
+  fi
+
   # Older RHEL/CentOS versions use [1], while newer versions (e.g. 7.1) and
   # Ubuntu/Debian use [2]:
   #   1: /sys/kernel/mm/redhat_transparent_hugepage/defrag


### PR DESCRIPTION
THP gets auto enabled on RHEL7

Added check for tuned service on RHEL/CentOS 7.x, it should be disabled:
https://www.cloudera.com/documentation/enterprise/latest/topics/cdh_admin_performance.html#xd_583c10bfdbd326ba-7dae4aa6-147c30d0933--7fd5__disable-tuned