### PR TITLE
Move "Mount" information next to the "Disks"

### DIFF
--- a/lib/info.sh
+++ b/lib/info.sh
@@ -37,6 +37,12 @@ function print_disks() {
     sudo fdisk -l $d 2>/dev/null | grep "^Disk /dev/" | cut -d' ' -f3-4 | cut -d',' -f1
   done
 
+  echo "Mount:"
+  findmnt -lo source,target,fstype,options | grep '^/dev' | \
+  while read line; do
+    pad; echo $line
+  done
+
   local mnts=`mount | grep /data || true`
   if [ "$mnts" ]; then
     echo "Data mounts:"
@@ -82,11 +88,6 @@ function print_network() {
   print_label "DNS server" `grep "^nameserver" /etc/resolv.conf | cut -d' ' -f2`
 }
 
-function print_mount() {
-  echo "Mount:"
-  printf "%s\n" "`findmnt -lo source,target,fstype,options | egrep -i '^/dev'`"
-}
-
 function system_info() {
   print_header "System information"
   print_fqdn
@@ -97,5 +98,4 @@ function system_info() {
   print_cloudera_rpms
   print_time
   print_network
-  print_mount
 }


### PR DESCRIPTION
```
Disks:
               /dev/sda  107.4 GB
Mount:
               /dev/sda1 / xfs rw,relatime,attr2,inode64,noquota
```

Previously it's displayed at the last:

```
Disks:
               /dev/sda  107.4 GB
Data mounts:   None found
Free space:
               /opt
               /var/log
Cloudera RPMs: None installed
Timezone:      America/Los_Angeles
DateTime:      Tue Jun 27 20:26:06 PDT 2017
nsswitch:      files dns myhostname
DNS server:    10.17.181.104
Mount:
/dev/sda1  /                               xfs        rw,relatime,attr2,inode64,noquota
```