### PR TITLE
Sanity check on hostname configuration

### DIFF
--- a/lib/checks.sh
+++ b/lib/checks.sh
@@ -144,11 +144,11 @@ function check_network() {
   fi
 
   # http://www.cloudera.com/content/www/en-us/documentation/enterprise/latest/topics/install_cdh_disable_iptables.html
-  if is_centos_rhel_7; then 
+  if is_centos_rhel_7; then
     _check_service_is_not_running 'Network' 'firewalld'
   else
     _check_service_is_not_running 'Network' 'iptables'
-  fi 
+  fi
   _check_service_is_running     'Network' 'nscd'
   _check_service_is_not_running 'Network' 'sssd'
 }
@@ -232,12 +232,46 @@ function _check_service_is_not_running() {
 
 function check_hostname() {
   local fqdn=`hostname -f`
-  local shortn=`hostname -s`
+  local short=`hostname -s`
 
-  if [[ `echo $fqdn | awk -F "." '{print $1}'` -eq $shortn  &&  `echo $fqdn | awk -F "." '{print NF}'` -gt 2 && ${#shortn} -le 15 ]]; then
-    state "Network: FQDN looks okay" 0
-  elif [ `echo $fqdn | awk -F '.' "{print NF}"` -lt 3 ]; then
-    state "Network: FQDN or /etc/hosts is misconfigured. \"hostname -f\" should return the FQDN" 1
+  # https://en.wikipedia.org/wiki/Hostname
+  # Hostnames are composed of series of labels concatenated with dots, as are
+  # all domain names. Each label must be from 1 to 63 characters long, and the
+  # entire hostname (including delimiting dots but not a trailing dot) has a
+  # maximum of 253 ASCII characters.
+  echo $fqdn | egrep -iq '^([a-z0-9][a-z0-9\-]{1,61}[a-z0-9]\.)+[a-z]+$'
+  local valid_format=$?
+  if [[ $valid_format -eq 0 && ${#fqdn} -le 253 ]]; then
+    if [[ ${#short} -gt 15 ]]; then
+      # Microsoft still recommends computer names less than or equal to 15 characters.
+      # https://serverfault.com/questions/123343/is-the-netbios-limt-of-15-charactors-still-a-factor-when-naming-computers
+      # https://technet.microsoft.com/en-us/library/cc731383.aspx
+      # If hostname is longer than that, we cannot do SSSD or Centrify etc to
+      # add the node to domain. Won't work well with Kerberos/AD.
+      state "Network: Computer name should be <= 15 characters (NetBIOS restriction)" 1
+    else
+      if [[ `echo $fqdn | sed -e 's/\..*//'` = $short ]]; then
+        if [[ `echo $fqdn | grep '[A-Z]'` = "" ]]; then
+          state "Network: Hostname looks good (FQDN, no uppercase letters)" 0
+        else
+          # Cluster hosts must have a working network name resolution system and
+          # correctly formatted /etc/hosts file. All cluster hosts must have properly
+          # configured forward and reverse host resolution through DNS.
+          # The /etc/hosts files must:
+          # - Not contain uppercase hostnames
+          # https://www.cloudera.com/documentation/enterprise/release-notes/topics/rn_consolidated_pcm.html#cm_cdh_compatibility
+          state "Network: Hostname should not contain uppercase letters" 1
+        fi
+      else
+        state "Network: Hostname misconfiguration (shortname and host label of FQDN don't match)" 2
+      fi
+    fi
+  else
+    # Important
+    # - The canonical name of each host in /etc/hosts `must' be the FQDN
+    # - Do not use aliases, either in /etc/hosts or in configuring DNS
+    # https://www.cloudera.com/documentation/enterprise/latest/topics/cdh_ig_networknames_configure.html
+    state "Network: Malformed hostname is configured (consult RFC)" 1
   fi
 }
 
@@ -254,7 +288,7 @@ function is_ntp_in_sync() {
     state "System: Clock is synchronized against the NTPD server" 0
   else
     state "System: NTP is not synchronized. Check ntpstat to troubleshoot" 1
-  fi 
+  fi
 }
 
 function check_only_64bit_packages_installed() {


### PR DESCRIPTION
- Each label must be from 1 to 63 characters long
- Entire hostname (including delimiting dots but not a trailing dot) has a
  maximum of 253 ASCII characters.
- Hostname must have FQDN
- Hostname should not contain uppercase letters
- Hostname (computer name) should have less than or equal to 15 characters
  (NetBIOS/AD/Kerberos restriction)