### PR TITLE
Use base1024 for memory report

### DIFF
--- a/lib/info.sh
+++ b/lib/info.sh
@@ -27,7 +27,7 @@ function print_os() {
 function print_cpu_and_ram() {
   local cpu=`grep -m1 "^model name" /proc/cpuinfo | cut -d' ' -f3- | sed -e 's/(R)//' -e 's/Core(TM) //' -e 's/CPU //'`
   print_label "CPUs" "`nproc`x $cpu"
-  print_label "RAM" "`awk '/MemTotal:/ {printf "%d GB", $2/1000/1000}' /proc/meminfo`"
+  print_label "RAM" "`awk '/MemTotal:/ {printf "%.1f GB", $2/1024/1024}' /proc/meminfo`"
 }
 
 function print_disks() {


### PR DESCRIPTION
Pull request to solve the issue #28 

The output format is also changed from:
    `RAM:           3 GB`
 to match the Host Details of Cloudera CSI.
    `RAM:           3.6 GB`
