### PR TITLE
Fix free memory report

### DIFF
--- a/lib/info.sh
+++ b/lib/info.sh
@@ -27,7 +27,14 @@ function print_os() {
 function print_cpu_and_ram() {
   local cpu=`grep -m1 "^model name" /proc/cpuinfo | cut -d' ' -f3- | sed -e 's/(R)//' -e 's/Core(TM) //' -e 's/CPU //'`
   print_label "CPUs" "`nproc`x $cpu"
-  print_label "RAM" "`awk '/MemTotal:/ {printf "%d GB", $2/1000/1000}' /proc/meminfo`"
+  set `free -h | awk '/Mem:/ {print $2,$3,$4,$5,$6,$7}'`
+  print_label "Memory" ""
+  pad; printf "%-12s%s\n" "total" $1
+  pad; printf "%-12s%s\n" "used" $2
+  pad; printf "%-12s%s\n" "free" $3
+  pad; printf "%-12s%s\n" "shared" $4
+  pad; printf "%-12s%s\n" "buff/cache" $5
+  pad; printf "%-12s%s\n" "available" $6
 }
 
 function print_disks() {


### PR DESCRIPTION
Changed to display full memory report from `free -h`

System information includes the following:
```
Memory:
               total       3.6G
               used        142M
               free        3.3G
               shared      8.2M
               buff/cache  160M
               available   3.3G
```

To solve the issue https://github.com/cloudera-ps/prereq-checks/issues/15