### PR TITLE
Use `free -h` result to see total installed memory

### DIFF
--- a/lib/info.sh
+++ b/lib/info.sh
@@ -27,7 +27,7 @@ function print_os() {
 function print_cpu_and_ram() {
   local cpu=`grep -m1 "^model name" /proc/cpuinfo | cut -d' ' -f3- | sed -e 's/(R)//' -e 's/Core(TM) //' -e 's/CPU //'`
   print_label "CPUs" "`nproc`x $cpu"
-  print_label "RAM" "`awk '/MemTotal:/ {printf "%d GB", $2/1000/1000}' /proc/meminfo`"
+  print_label "RAM" "`awk '/MemTotal:/ {printf "%.1f GB", $2/1024/1024}' /proc/meminfo`"
 }
 
 function print_disks() {

--- a/lib/info.sh
+++ b/lib/info.sh
@@ -27,7 +27,8 @@ function print_os() {
 function print_cpu_and_ram() {
   local cpu=`grep -m1 "^model name" /proc/cpuinfo | cut -d' ' -f3- | sed -e 's/(R)//' -e 's/Core(TM) //' -e 's/CPU //'`
   print_label "CPUs" "`nproc`x $cpu"
-  print_label "RAM" "`awk '/MemTotal:/ {printf "%.1f GB", $2/1024/1024}' /proc/meminfo`"
+  # Total installed memory (MemTotal and SwapTotal in /proc/meminfo)
+  print_label "RAM" "`free -h | awk '/Mem:/ {print $2}'`"
 }
 
 function print_disks() {


### PR DESCRIPTION
The output from free command is more accurate and human readable. "total" indicates the total installed memory (`MemTotal` and `SwapTotal` in` /proc/meminfo`)

```
[root@maru-centos73 prereq-checks]# free -h
              total        used        free      shared  buff/cache   available
Mem:           3.6G        143M        3.3G        8.2M        169M        3.3G
Swap:            0B          0B          0B
```
