### PR TITLE
Change distro name format in system information

### DIFF
--- a/lib/info.sh
+++ b/lib/info.sh
@@ -18,7 +18,10 @@ function print_fqdn() {
 function print_os() {
   local distro="Unknown"
   if [ -f /etc/redhat-release ]; then
-    distro=`sed -e 's/release //' -e 's/ (Final)//' /etc/redhat-release`
+    distro=$( sed -e 's/ release / /' \
+                  -e 's/ ([[:alnum:]]*)//' \
+                  -e 's/CentOS Linux \([0-9]\).\([0-9]\).*/CentOS \1.\2/' \
+                  /etc/redhat-release )
   fi
   print_label "Distro" "$distro"
   print_label "Kernel" `uname -r`


### PR DESCRIPTION
From
`Distro:        CentOS Linux 7.3.1611 (Core) `

To
`Distro:        CentOS 7.3`

CentOS 6.x releases are shown as follows:
`Distro:        CentOS 6.9`