### PR TITLE
Check /tmp is mounted with noexec option or not

### DIFF
--- a/lib/checks.sh
+++ b/lib/checks.sh
@@ -193,9 +193,9 @@ function check_os() {
     fi
   done
   if $noexec; then
-    state "System: /tmp mounted with noexec option cause troubles in older version of CMs" 2
+    state "System: /tmp mounted with noexec fails for CM versions older than 5.8.4, 5.9.2, and 5.10.0" 2
   else
-    state "System: /tmp mounted with noexec option cause troubles in older version of CMs" 0
+    state "System: /tmp mounted with noexec fails for CM versions older than 5.8.4, 5.9.2, and 5.10.0" 0
   fi
 }
 

--- a/lib/checks.sh
+++ b/lib/checks.sh
@@ -185,6 +185,18 @@ function check_os() {
   else
     state "System: Only 64bit packages should be installed" 0
   fi
+
+  local noexec=false
+  for option in `findmnt -lno options --target /tmp | tr ',' ' '`; do
+    if [[ $option = 'noexec' ]]; then
+      noexec=true
+    fi
+  done
+  if $noexec; then
+    state "System: /tmp mounted with noexec option cause troubles in older version of CMs" 2
+  else
+    state "System: /tmp mounted with noexec option cause troubles in older version of CMs" 0
+  fi
 }
 
 function check_database() {


### PR DESCRIPTION
Older versions of Cloudera Manager fail in adding a new host if
noexec option is specified for /tmp filesystem. This problem is
solved in 5.8.4, 5.9.2, 5.10.0 and later.

Added check for noexec option and issue WARN message if it's specified:

 * Without noexec option
![issue049-000](https://user-images.githubusercontent.com/226835/28411604-3c81c716-6d7c-11e7-97af-561131035013.png)

 * With noexec option 
![issue049-001](https://user-images.githubusercontent.com/226835/28411603-3c80a3d6-6d7c-11e7-825d-dc24398eea7a.png)
