### PR TITLE
Check unneeded services are not running

### DIFF
--- a/lib/checks.sh
+++ b/lib/checks.sh
@@ -197,9 +197,9 @@ function check_os() {
     _check_service_is_running 'DUMMY' ${svc} > /dev/null
     local svc_running=${SERVICE_STATUS['running']}
     if $svc_running; then
-      state "System: $svc is running (unneeded)" 2
+      state "System: $svc is running (not recommended)" 2
     else
-      state "System: $svc is not running (unneeded)" 0
+      state "System: $svc is not running (recommended)" 0
     fi
   done
 

--- a/lib/checks.sh
+++ b/lib/checks.sh
@@ -186,6 +186,23 @@ function check_os() {
     state "System: Only 64bit packages should be installed" 0
   fi
 
+  local UNNECESSARY_SERVICES=(
+    'bluetooth'
+    'cups'
+    'iptables'
+    'ip6tables'
+    'postfix'
+  )
+  for svc in ${UNNECESSARY_SERVICES[@]}; do
+    _check_service_is_running 'DUMMY' ${svc} > /dev/null
+    local svc_running=${SERVICE_STATUS['running']}
+    if $svc_running; then
+      state "System: $svc is running (unneeded)" 2
+    else
+      state "System: $svc is not running (unneeded)" 0
+    fi
+  done
+
   local noexec=false
   for option in `findmnt -lno options --target /tmp | tr ',' ' '`; do
     if [[ $option = 'noexec' ]]; then


### PR DESCRIPTION
The following services are known as unnecessary:
bluetooth, cups, iptables, ip6tables, postfix

![issue042-000](https://user-images.githubusercontent.com/226835/28459294-cfbda826-6e47-11e7-8505-d8c5570e4d2b.png)
![issue042-001](https://user-images.githubusercontent.com/226835/28459293-cfbd7d60-6e47-11e7-896e-674c2f666aee.png)

Should we use 'FAIL' for unnecessary services running? 