### PR TITLE
Fix FQDN check

### DIFF
--- a/lib/checks.sh
+++ b/lib/checks.sh
@@ -519,7 +519,8 @@ function check_hostname() {
   # all domain names. Each label must be from 1 to 63 characters long, and the
   # entire hostname (including delimiting dots but not a trailing dot) has a
   # maximum of 253 ASCII characters.
-  echo $fqdn | grep -Eiq '^([a-z0-9][a-z0-9\-]{1,61}[a-z0-9]\.)+[a-z]+$'
+  local VALID_FQDN='^([a-z]([a-z0-9\-]{0,61}[a-z0-9])?\.)+[a-z]([a-z0-9\-]{0,61}[a-z0-9])?$'
+  echo $fqdn | grep -Eiq $VALID_FQDN
   local valid_format=$?
   if [[ $valid_format -eq 0 && ${#fqdn} -le 253 ]]; then
     if [[ ${#short} -gt 15 ]]; then


### PR DESCRIPTION
RFC1035 defines a valid domain name as follows:

```
<domain> ::= <subdomain> | " "

<subdomain> ::= <label> | <subdomain> "." <label>

<label> ::= <letter> [ [ <ldh-str> ] <let-dig> ]

<ldh-str> ::= <let-dig-hyp> | <let-dig-hyp> <ldh-str>

<let-dig-hyp> ::= <let-dig> | "-"

<let-dig> ::= <letter> | <digit>

<letter> ::= any one of the 52 alphabetic characters A through Z in
upper case and a through z in lower case

<digit> ::= any one of the ten digits 0 through 9
```

Note that while upper and lower case letters are allowed in domain
names, no significance is attached to the case.  That is, two names with
the same spelling but different case are to be treated as if identical.

The labels must follow the rules for ARPANET host names.  They must
start with a letter, end with a letter or digit, and have as interior
characters only letters, digits, and hyphen.  There are also some
restrictions on the length.  Labels must be 63 characters or less.