### PR TITLE
added AD integration privileges check, fix for Timezone and internet checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ by using [Ansible](https://www.ansible.com/) to automate distribution and
 execution of the script file(s) and gathering the inspection results from
 the multiple target hosts.
 
+## Prerequisites
+1. For using the distributed mode, run
+`    yum install ansible`
+2. For using the AD domain controller checks, run
+`    yum install perl-Convert-ASN1`
+3. For using the AD delegated user privilege checks, run
+`    yum install openldap-clients`
+
 ## Running it locally
 
 Running the script is easy as it is intentionally written in Bash to avoid any
@@ -80,8 +88,8 @@ Simply execute it like in Option A:
 | --- | --- |
 | ./prereq-check.sh | run system check (default) |
 | ./prereq-check.sh --help | show usage |
-| ./prereq-chesk.sh --security &lt;domain&gt; | run security check |
-&lt;domain&gt; : LDAP domain name like AD.CLOUDERA.COM
+| ./prereq-chesk.sh --addc &lt;domain&gt; | run AD domain controller related checks |
+| ./prereq-chesk.sh --usertest &lt;domain&gt; | run tests against Active Directory delegated user for Direct to AD integration |
 
 ## Running it with Ansible
 

--- a/lib/checks.sh
+++ b/lib/checks.sh
@@ -264,12 +264,6 @@ function check_jdbc_connector() {
 declare -A SERVICE_STATUS
 
 function check_network() {
-  if [ `ping -W1 -c1 8.8.8.8 &>/dev/null; echo $?` -eq 0 ]; then
-    state "Network: Has Internet connection" 0
-  else
-    state "Network: No Internet connection" 2
-  fi
-
   check_hostname
 
   local entries=`cat /etc/hosts | grep -Ev "^#|^ *$" | wc -l`
@@ -593,7 +587,7 @@ function checks() {
 #
 # Code previously reside in verify.sh
 #
-function check_security() {
+function check_addc() {
   # the domainname passed by the caller, already checked to be non-empty
   DOMAIN=$1
   # the directory of the script
@@ -644,5 +638,50 @@ function check_security() {
     else
       echo "DOMAIN NOT FOUND"
     fi
+  fi
+}
+
+function check_privs
+{
+  print_header "Prerequisite checks: Direct to AD integration:"
+  ldapsearch -x -H ${ARG_LDAPURI} -D ${ARG_BINDDN} -b "${ARG_SEARCHBASE}"  -L -w ${ARG_USERPSWD} > /dev/zero 2>/dev/zero
+  SRCH_RESULT=$?
+  if [ $SRCH_RESULT -eq 0 ]; then
+    state "User exists" 0
+    cat > /tmp/prereq-check.ldif <<EOFILE
+dn: CN=Cloudera User,${ARG_SEARCHBASE}
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: user
+EOFILE
+#NOTE: Heredoc requires the above spacing/format or it won't work.
+    ldapadd -x -H ${ARG_LDAPURI} -a -D ${ARG_BINDDN} -f /tmp/prereq-check.ldif -w ${ARG_USERPSWD} > /dev/zero 2>/dev/zero
+    ADD_RESULT=$?
+    if [ $ADD_RESULT -eq 0 ]; then
+      state "Has delegated privileges to add a new user on the OU" 0
+      ldapdelete -H ${ARG_LDAPURI} -D ${ARG_BINDDN} "CN=Cloudera User,${ARG_SEARCHBASE}" -w ${ARG_USERPSWD}
+      DEL_RESULT=$?
+      if [ $DEL_RESULT -eq 0 ]; then
+        state "Has delegated privileges to delete a user on the OU" 0
+        state "Sufficient privileges available to perform a direct to AD integration" 0
+      fi
+    elif [ $ADD_RESULT -eq 50 ]; then
+      state "ldap_add: Insufficient access (50)" 1
+    elif [ $ADD_RESULT -eq 68 ]; then
+      state "ldap_add: Already exists (68)" 1
+    else
+      state "Not able to add user" 1
+    fi
+  elif [ $SRCH_RESULT -eq 49 ]; then
+    state "Invalid credentials - ldap_bind(49)" 1
+  elif [ $SRCH_RESULT -eq 10 ]; then
+    state "Possible invalid BaseDN - ldap_bind(10)" 1
+  elif [ $SRCH_RESULT -eq 255 ]; then
+    state "Not able to find the LDAP server specified" 1
+  elif [ $SRCH_RESULT -eq 34 ]; then
+    state "Invalid DN syntax (34)" 1
+  else
+    state -e "Unrecognized error occured. Not able to connect to AD using\n\tLDAPURI: ${ARG_LDAPURI}\n\tBINDDN: ${ARG_BINDDN}\n\tSEARCHBASE: ${ARG_SEARCHBASE}\n\tand provided password" 1
   fi
 }

--- a/lib/info.sh
+++ b/lib/info.sh
@@ -5,11 +5,7 @@ function print_label() {
 }
 
 function print_time() {
-  if is_centos_rhel_7; then
-    local timezone=`timedatectl | awk '/^\s+Time zone:/ { print $3 }'`
-  else
-    local timezone=`ls -l /etc/localtime | sed -e 's!^.*zoneinfo/!!'`
-  fi
+  local timezone=`date | awk '{print $(NF-1)}'`
   timezone=${timezone:-UTC}
   print_label "Timezone" "$timezone"
   print_label "DateTime" "`date`"
@@ -148,6 +144,14 @@ function print_network() {
   print_label "DNS server" `grep "^nameserver" /etc/resolv.conf | cut -d' ' -f2`
 }
 
+function print_internet() {
+  if [ `ping -W1 -c1 8.8.8.8 &>/dev/null; echo $?` -eq 0 ]; then
+    print_label "Internet" "Yes"
+  else
+    print_label "Internet" "No"
+  fi
+}
+
 function system_info() {
   print_header "System information"
   print_fqdn
@@ -158,4 +162,5 @@ function system_info() {
   print_cloudera_rpms
   print_time
   print_network
+  print_internet
 }

--- a/prereq-check.sh
+++ b/prereq-check.sh
@@ -57,22 +57,32 @@ function usage() {
   echo "  -h, --help"
   echo "    Show this message"
   echo
-  echo "  -s, --security `tput smul`domain`tput sgr0`"
-  echo "    Run security checks"
+  echo "  -a, --addc `tput smul`domain`tput sgr0`"
+  echo "    Run tests against Active Directory Domain Controller"
+  echo
+  echo "  -u, --usertest `tput smul`ldapURI`tput sgr0` `tput smul`binddn`tput sgr0` `tput smul`searchbase`tput sgr0` `tput smul`bind_user_password`tput sgr0`"
+  echo "    Run tests against Active Directory delegated user for Direct to AD integration"
+  echo "    http://blog.cloudera.com/blog/2014/07/new-in-cloudera-manager-5-1-direct-active-directory-integration-for-kerberos-authentication/"
   echo
   exit 1
 }
 
-while [[ $# -gt 0 ]]; do
+if [[ $# -gt 0 ]]; then
   KEY=$1
   case ${KEY} in
     -h|--help)
       OPT_USAGE=true
       ;;
-    -s|--security)
+    -a|--addc)
       OPT_DOMAIN=true
       ARG_DOMAIN=$2
-      shift # Past argument
+      ;;
+    -p|--privilegetest)
+      OPT_USER=true
+      ARG_LDAPURI=$2
+      ARG_BINDDN=$3
+      ARG_SEARCHBASE=$4
+      ARG_USERPSWD=$5
       ;;
     *)
       # Unknown option
@@ -80,8 +90,7 @@ while [[ $# -gt 0 ]]; do
       >&2 echo "Unknown option: ${KEY}"
       ;;
   esac
-  shift # Past argument or value
-done
+fi
 
 if [[ ${OPT_USAGE} ]]; then
   usage
@@ -90,7 +99,14 @@ elif [[ ${OPT_DOMAIN} ]]; then
     >&2 echo "Missing domain argument. ex) AD.CLOUDERA.COM"
     usage
   else
-    check_security ${ARG_DOMAIN}
+    check_addc ${ARG_DOMAIN}
+  fi
+elif [[ ${OPT_USER} ]]; then
+  if [[ -z ${ARG_LDAPURI} || -z ${ARG_BINDDN} || -z ${ARG_SEARCHBASE} || -z ${ARG_USERPSWD} ]]; then
+    >&2 echo "Options missing"
+    usage
+  else
+    check_privs ${ARG_LDAPURI} ${ARG_BINDDN} ${ARG_SEARCHBASE}
   fi
 else
   echo ${BANNER}
@@ -102,3 +118,4 @@ else
   checks
   echo
 fi
+

--- a/prereq-check.sh
+++ b/prereq-check.sh
@@ -60,7 +60,7 @@ function usage() {
   echo "  -a, --addc `tput smul`domain`tput sgr0`"
   echo "    Run tests against Active Directory Domain Controller"
   echo
-  echo "  -u, --usertest `tput smul`ldapURI`tput sgr0` `tput smul`binddn`tput sgr0` `tput smul`searchbase`tput sgr0` `tput smul`bind_user_password`tput sgr0`"
+  echo "  -p, --privilegetest `tput smul`ldapURI`tput sgr0` `tput smul`binddn`tput sgr0` `tput smul`searchbase`tput sgr0` `tput smul`bind_user_password`tput sgr0`"
   echo "    Run tests against Active Directory delegated user for Direct to AD integration"
   echo "    http://blog.cloudera.com/blog/2014/07/new-in-cloudera-manager-5-1-direct-active-directory-integration-for-kerberos-authentication/"
   echo


### PR DESCRIPTION
Added new option AD integration privileges check
Fix issues with Timezone and internet check
Changed existing "security" check's naming

AD integration check will provide results like the following:
<img width="608" alt="screen shot 2017-08-08 at 9 21 59 pm" src="https://user-images.githubusercontent.com/4425664/29073864-d36bbc6a-7c7f-11e7-8623-95a4c108fff4.png">

These issues are tracked under #71  #69  #84 