### PR TITLE
fix: when free doesn't support human-readable flag

### DIFF
--- a/lib/info.sh
+++ b/lib/info.sh
@@ -37,7 +37,7 @@ function print_cpu_and_ram() {
   # Total installed memory (MemTotal and SwapTotal in /proc/meminfo)
   # special case for CentOS 6.5 and older which doesn't support human-readable -h flag
   if [[ $(free -V) =~ "3.2.8" ]] ; then
-    print_label "RAM" "`free -m | awk '/Mem:/ {print $2}'`GB"
+    print_label "RAM" "`free -g | awk '/Mem:/ {print $2}'`GB"
   else
     print_label "RAM" "`free -h | awk '/Mem:/ {print $2}'`"
   fi

--- a/lib/info.sh
+++ b/lib/info.sh
@@ -35,7 +35,12 @@ function print_cpu_and_ram() {
   local cpu=`grep -m1 "^model name" /proc/cpuinfo | cut -d' ' -f3- | sed -e 's/(R)//' -e 's/Core(TM) //' -e 's/CPU //'`
   print_label "CPUs" "`nproc`x $cpu"
   # Total installed memory (MemTotal and SwapTotal in /proc/meminfo)
-  print_label "RAM" "`free -h | awk '/Mem:/ {print $2}'`"
+  # special case for CentOS 6.5 and older which doesn't support human-readable -h flag
+  if [[ $(free -V) =~ "3.2.8" ]] ; then
+    print_label "RAM" "`free -m | awk '/Mem:/ {print $2}'`GB"
+  else
+    print_label "RAM" "`free -h | awk '/Mem:/ {print $2}'`"
+  fi
 }
 
 function print_disks() {

--- a/lib/info.sh
+++ b/lib/info.sh
@@ -35,12 +35,7 @@ function print_cpu_and_ram() {
   local cpu=`grep -m1 "^model name" /proc/cpuinfo | cut -d' ' -f3- | sed -e 's/(R)//' -e 's/Core(TM) //' -e 's/CPU //'`
   print_label "CPUs" "`nproc`x $cpu"
   # Total installed memory (MemTotal and SwapTotal in /proc/meminfo)
-  # special case for CentOS 6.5 and older which doesn't support human-readable -h flag
-  if [[ $(free -V) =~ "3.2.8" ]] ; then
-    print_label "RAM" "`free -g | awk '/Mem:/ {print $2}'`GB"
-  else
-    print_label "RAM" "`free -h | awk '/Mem:/ {print $2}'`"
-  fi
+  print_label "RAM" "$(awk '/^MemTotal:/ { printf "%.2f", $2/1024/1024 ; exit}' /proc/meminfo)G"
 }
 
 function print_disks() {


### PR DESCRIPTION
Null output for Memory check when running on OS without human-readable flag -h support for `free`. Last seen with CentOS 6.5, but likely a problem for other OS as well.

```
Distro:        CentOS 6.5
Kernel:        2.6.32-431.el6.x86_64
CPUs:          2x Intel Xeon(R) E5-2630 v3 @ 2.40GHz
free: invalid option -- 'h'
usage: free [-b|-k|-m|-g] [-l] [-o] [-t] [-s delay] [-c count] [-V]
  -b,-k,-m,-g show output in bytes, KB, MB, or GB
  -l show detailed low and high memory statistics
  -o use old format (no -/+buffers/cache line)
  -t display total for RAM + swap
  -s update every [delay] seconds
  -c update [count] times
  -V display version information and exit
RAM:
```