### PR TITLE
Servers with Kerberos enabled stop functioning when using OpenJDK 1.8u242

### DIFF
--- a/lib/checks.sh
+++ b/lib/checks.sh
@@ -113,12 +113,11 @@ function check_java() {
                         if [[ ${BASH_REMATCH[1]} -eq 7 ]]; then
                             state "Java: Unsupported OpenJDK: ${candidate}/bin/java" 1
                         elif [[ ${BASH_REMATCH[1]} -eq 8 ]]; then
-                            # https://bugs.openjdk.java.net/browse/JDK-8215032
-                            if [[ ${BASH_REMATCH[2]} -eq 242 ]]; then
-                                state "Servers with Kerberos enabled stop functioning when using OpenJDK 1.8u242" 2
-                            fi
                             if [[ ${BASH_REMATCH[2]} -lt 181 ]]; then
                                 state "Java: Unsupported OpenJDK: ${candidate}/bin/java" 1
+                            elif [[ ${BASH_REMATCH[2]} -eq 242 ]]; then
+                                # https://bugs.openjdk.java.net/browse/JDK-8215032
+                                state "Servers with Kerberos enabled stop functioning when using OpenJDK 1.8u242" 2
                             else
                                 state "Java: Supported OpenJDK (CDH 5.16.1+ or 6.1.0+ only): ${candidate}/bin/java" 0
                             fi

--- a/lib/checks.sh
+++ b/lib/checks.sh
@@ -113,6 +113,10 @@ function check_java() {
                         if [[ ${BASH_REMATCH[1]} -eq 7 ]]; then
                             state "Java: Unsupported OpenJDK: ${candidate}/bin/java" 1
                         elif [[ ${BASH_REMATCH[1]} -eq 8 ]]; then
+                            # https://bugs.openjdk.java.net/browse/JDK-8215032
+                            if [[ ${BASH_REMATCH[2]} -eq 242 ]]; then
+                                state "Servers with Kerberos enabled stop functioning when using OpenJDK 1.8u242" 2
+                            fi
                             if [[ ${BASH_REMATCH[2]} -lt 181 ]]; then
                                 state "Java: Unsupported OpenJDK: ${candidate}/bin/java" 1
                             else


### PR DESCRIPTION
#137
https://my.cloudera.com/knowledge/Cloudera-Customer-Advisory-Servers-with-Kerberos-enabled-stop?id=292027

Added Warning message

```

# Installing OpenJDK1.8 242 for testing
yum search jdk
yum install -y java-1.8.0-openjdk-devel.i686  1:1.8.0.242.b08-0.el7_7
```