### PR TITLE
Fix spn check bugs

### DIFF
--- a/ansible/roles/prereq-checks/files/prereq-check.sh
+++ b/ansible/roles/prereq-checks/files/prereq-check.sh
@@ -591,7 +591,7 @@ function check_privs() {
     print_header "AD privilege checks"
     
     ### disable cert verification if using ldaps
-    #export LDAPTLS_REQCERT=never
+    export LDAPTLS_REQCERT=never
     
     STDERR=$(ldapsearch -x -H "${ARG_LDAPURI}" -D "${ARG_BINDDN}" -b "${ARG_SEARCHBASE}"  -L -w "${ARG_USERPSWD}" 2>&1 >/dev/zero)
     SRCH_RESULT=$?
@@ -655,7 +655,7 @@ function check_spn_uniqueness() {
     HOSTNAME=$(hostname -f)
     RANDOM_CN=prereqchk03
 
-    SEARCHBASE=$(echo ${ARG_SEARCHBASE} | grep -o 'dc=.*')
+    SEARCHBASE=$(echo ${ARG_SEARCHBASE} | grep -io 'dc=.*')
 
     ldapsearch -x -H "${ARG_LDAPURI}" -D "${ARG_BINDDN}" -w "${ARG_USERPSWD}" -b "${SEARCHBASE}" "servicePrincipalName=HTTP/${HOSTNAME}" | grep "^cn:" 2>&1 > /dev/null
     SRCH_RESULT=$?

--- a/lib/security/security-checks.sh
+++ b/lib/security/security-checks.sh
@@ -46,7 +46,7 @@ function check_privs() {
     print_header "AD privilege checks"
     
     ### disable cert verification if using ldaps
-    #export LDAPTLS_REQCERT=never
+    export LDAPTLS_REQCERT=never
     
     STDERR=$(ldapsearch -x -H "${ARG_LDAPURI}" -D "${ARG_BINDDN}" -b "${ARG_SEARCHBASE}"  -L -w "${ARG_USERPSWD}" 2>&1 >/dev/zero)
     SRCH_RESULT=$?
@@ -110,7 +110,7 @@ function check_spn_uniqueness() {
     HOSTNAME=$(hostname -f)
     RANDOM_CN=prereqchk03
 
-    SEARCHBASE=$(echo ${ARG_SEARCHBASE} | grep -o 'dc=.*')
+    SEARCHBASE=$(echo ${ARG_SEARCHBASE} | grep -io 'dc=.*')
 
     ldapsearch -x -H "${ARG_LDAPURI}" -D "${ARG_BINDDN}" -w "${ARG_USERPSWD}" -b "${SEARCHBASE}" "servicePrincipalName=HTTP/${HOSTNAME}" | grep "^cn:" 2>&1 > /dev/null
     SRCH_RESULT=$?

--- a/prereq-check.sh
+++ b/prereq-check.sh
@@ -591,7 +591,7 @@ function check_privs() {
     print_header "AD privilege checks"
     
     ### disable cert verification if using ldaps
-    #export LDAPTLS_REQCERT=never
+    export LDAPTLS_REQCERT=never
     
     STDERR=$(ldapsearch -x -H "${ARG_LDAPURI}" -D "${ARG_BINDDN}" -b "${ARG_SEARCHBASE}"  -L -w "${ARG_USERPSWD}" 2>&1 >/dev/zero)
     SRCH_RESULT=$?
@@ -655,7 +655,7 @@ function check_spn_uniqueness() {
     HOSTNAME=$(hostname -f)
     RANDOM_CN=prereqchk03
 
-    SEARCHBASE=$(echo ${ARG_SEARCHBASE} | grep -o 'dc=.*')
+    SEARCHBASE=$(echo ${ARG_SEARCHBASE} | grep -io 'dc=.*')
 
     ldapsearch -x -H "${ARG_LDAPURI}" -D "${ARG_BINDDN}" -w "${ARG_USERPSWD}" -b "${SEARCHBASE}" "servicePrincipalName=HTTP/${HOSTNAME}" | grep "^cn:" 2>&1 > /dev/null
     SRCH_RESULT=$?


### PR DESCRIPTION
1. Change grep to be case insensitive
2. Uncomment export to disable cert verification

https://github.com/cloudera-ps/prereq-checks/issues/148